### PR TITLE
Updated moment dependency version due to security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-brute": "~0.5.0"
   },
   "dependencies": {
-    "moment": "~1.7.2",
+    "moment": "~2.13.0",
     "xtend": "~2.1.1"
   }
 }


### PR DESCRIPTION
Running "nsp check --output summary" on the project revealed a security vulnerability with the existing version of moment.js.  Recommend updating to the latest version.